### PR TITLE
Fix indentation for privacy/terms pages sub-lists

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ description: >- # this means to ignore newlines until "baseurl:"
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Build settings
-markdown: CommonMarkGhPages
+markdown: kramdown
 remote_theme: isomerpages/isomerpages-template
 safe: false
 

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ description: >- # this means to ignore newlines until "baseurl:"
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Build settings
-markdown: kramdown
+markdown: CommonMarkGhPages
 remote_theme: isomerpages/isomerpages-template
 safe: false
 

--- a/_starter-kit/2-set-up-your-software-env.md
+++ b/_starter-kit/2-set-up-your-software-env.md
@@ -17,7 +17,7 @@ Proceed with the following steps, depending on which Operating System your devel
 <br>
 
 <details>
-  <summary><font size=4>Mbed Studio Setup</font size></summary>
+  <summary>Mbed Studio Setup</summary>
 
   1. Create an Mbed Account at <https://os.mbed.com/account/signup/> (This account is required to use Mbed Studio IDE)
   2. Download Mbed Studio from <https://os.mbed.com/studio/>
@@ -27,7 +27,7 @@ Proceed with the following steps, depending on which Operating System your devel
 
 <br>
 <details>
-  <summary><font size=4>Visual Studio Code Setup</font size></summary>
+  <summary>Visual Studio Code Setup</summary>
 
   1. Download VS Code for Ubuntu at <https://code.visualstudio.com/download>
   2. Install VS Code
@@ -102,7 +102,7 @@ ___
 This program will allow you to read the serial debug output from the MANUCA DK. Proceed with the following steps to install your serial debug program, depending on which OS your computer is running on.
 <details>
   
-  <summary><font size=4>Linux</font size></summary>
+  <summary>Linux</summary>
 
   1. Install minicom by entering the following line into Terminal. This step will install minicom if not installed yet.
   ~~~bash
@@ -115,7 +115,7 @@ This program will allow you to read the serial debug output from the MANUCA DK. 
 <br>
 <details>
   
-  <summary><font size=4>MacOS</font size></summary>
+  <summary>MacOS</summary>
 
   1. Install minicom using the following commands in Terminal:  
   ~~~bash
@@ -129,7 +129,7 @@ This program will allow you to read the serial debug output from the MANUCA DK. 
 <br>
 <details>
   
-  <summary><font size=4>Windows</font size></summary>
+  <summary>Windows</summary>
   
   1. Download [Tera Term](https://osdn.net/projects/ttssh2/releases/) for Windows.
 

--- a/_starter-kit/3-set-up-your-hardware.md
+++ b/_starter-kit/3-set-up-your-hardware.md
@@ -31,7 +31,7 @@ collection_name: starter-kit
 Proceed with the following steps, depending on which OS your computer is running on.
 <details>
   
-  <summary><font size=4>Linux</font size></summary>
+  <summary>Linux</summary>
   
   1. Find out which serial port your **TTL-USB Cable** is connected to by disconnecting your **TTL-USB Cable**, then entering in Terminal:
       ~~~bash
@@ -85,7 +85,7 @@ Proceed with the following steps, depending on which OS your computer is running
 <br>
 <details>
   
-  <summary><font size=4>MacOS</font size></summary>
+  <summary>MacOS</summary>
   
   1. Find out which serial port your **TTL-USB Cable** is connected to by disconnecting your **TTL-USB Cable**, then entering in Terminal:
       ~~~bash
@@ -131,7 +131,7 @@ Proceed with the following steps, depending on which OS your computer is running
 <br>
 <details>
   
-  <summary><font size=4>Windows</font size></summary>
+  <summary>Windows</summary>
   
   1. Download [Tera Term](https://osdn.net/projects/ttssh2/releases/) for Windows.
 

--- a/_starter-kit/4-build-and-flash-software.md
+++ b/_starter-kit/4-build-and-flash-software.md
@@ -9,7 +9,7 @@ collection_name: starter-kit
 # 1. Open the Source Code
 
 <details>
-  <summary><font size=4>Mbed Studio</font size></summary>
+  <summary>Mbed Studio</summary>
 
   1. Open Mbed Studio and login using your Mbed account
   2. Go to File → Open Workspace → \<workspace_directory> (the workspace you have created in [Set up your Software Environment: Pulling the MANUCA OS into your IDE](/starter-kit/set-up-your-software-env/#Workspace))  
@@ -18,7 +18,7 @@ collection_name: starter-kit
 
 <br>
 <details>
-  <summary><font size=4>Visual Studio Code</font size></summary>
+  <summary>Visual Studio Code</summary>
 
   1. In VS Code, go to File → Open Workspace... → \<workspace_directory> (the workspace you have created in [Set up your Software Environment: Pulling the MANUCA OS into your IDE](/starter-kit/set-up-your-software-env/#Workspace))  
 </details>
@@ -69,7 +69,7 @@ mbedtls_ssl_conf_authmode(get_ssl_config(), MBEDTLS_SSL_VERIFY_NONE);
 # 3. Build the binary
 
 <details>
-  <summary><font size=4>Mbed Studio</font size></summary>
+  <summary>Mbed Studio</summary>
 
   1. In Mbed Studio, ensure target is set to **NUCLEO-F767ZI (NUCLEO_F767ZI)**
   2. We use C++11 as the standard for software development. Under Build profile, select **Import custom profiles**.  
@@ -90,7 +90,7 @@ mbedtls_ssl_conf_authmode(get_ssl_config(), MBEDTLS_SSL_VERIFY_NONE);
 
 <br>
 <details>
-  <summary><font size=4>Visual Studio Code</font size></summary>
+  <summary>Visual Studio Code</summary>
 
   2. In VS Code's terminal (or your regular terminal) enter the following line to compile:
   

--- a/misc/custom.scss
+++ b/misc/custom.scss
@@ -36,6 +36,12 @@ $desktop: 960px + (2 * $gap) !default;
   max-width: 100%;
 }
 
+details summary {
+  font-size: 1.2em;
+  cursor: pointer;
+  color: $primary;
+}
+
 // Mixins
 
 @mixin touch() {

--- a/pages/privacy.md
+++ b/pages/privacy.md
@@ -13,15 +13,15 @@ breadcrumb: Privacy
 
 3. You can choose to accept or decline cookies. Most web browsers automatically accept cookies, but you can usually modify your browser setting to decline cookies if you prefer. This may prevent you from taking full advantage of the website.
 
-4. If you provide us with personally identifiable data
-   : (a) We may share necessary data with other Government agencies, so as to serve you in the most efficient and effective way unless such sharing is prohibited by law.
-   : (b) We will NOT share your Personal Data with non-Government entities, except where such entities have been authorised to carry out specific Government services.
-   : (c) For your convenience, we may also display to you data you had previously supplied us or other Government Agencies. This will speed up the transaction and save you the trouble of repeating previous submissions. Should the data be out-of-date, please supply us the latest data.
+4. If you provide us with personally identifiable data  
+  (a) We may share necessary data with other Government agencies, so as to serve you in the most efficient and effective way unless such sharing is prohibited by law.  
+  (b) We will NOT share your Personal Data with non-Government entities, except where such entities have been authorised to carry out specific Government services.  
+  (c) For your convenience, we may also display to you data you had previously supplied us or other Government Agencies. This will speed up the transaction and save you the trouble of repeating previous submissions. Should the data be out-of-date, please supply us the latest data.  
 
 5. To safeguard your Personal Data, all electronic storage and transmission of Personal Data is secured with appropriate security technologies.
 
 6. This site may contain links to non-Government sites whose data protection and privacy practices may differ from ours. We are not responsible for the content and privacy practices of these other websites and encourage you to consult the privacy notices of those sites.
 
-7. Please contact 1800 211 0777 or [qsm@tech.gov.sg](mailto:qsm@tech.gov.sg) if you:
-   : (a) have any enquires or feedback on our data protection policies and procedures,
-   : (b) need more information on or access to data which you have provided to us in the past.
+7. Please contact 1800 211 0777 or [qsm@tech.gov.sg](mailto:qsm@tech.gov.sg) if you:  
+  (a) have any enquires or feedback on our data protection policies and procedures,  
+  (b) need more information on or access to data which you have provided to us in the past.  

--- a/pages/terms-of-use.md
+++ b/pages/terms-of-use.md
@@ -27,25 +27,24 @@ breadcrumb: Terms of Use
 
 ### **Disclaimers against Warranties, Representations and Liability**
 
-1. This Website and the Contents are provided on an "as is" and “as available” basis without warranties of any kind. To the fullest extent permitted by law, GovTech does not make any representations or warranties whatsoever and hereby disclaims all express, implied and statutory warranties of any kind to you or any third party, whether arising from usage or custom or trade or by operation of law or otherwise, including but not limited to the following:
-   : a. any representations or warranties as to the accuracy, completeness, reliability, timeliness, currency, quality or fitness for any particular purpose of the Contents of this Website; and
-   : b. any representations or warranties that the Contents and functions available on this Website shall be error-free or shall be available without interruption or delay, or that any defects on this Website shall be rectified or corrected, or that this Website, the Contents and the hosting servers are and will be free of all viruses and other harmful elements.
+1. This Website and the Contents are provided on an "as is" and “as available” basis without warranties of any kind. To the fullest extent permitted by law, GovTech does not make any representations or warranties whatsoever and hereby disclaims all express, implied and statutory warranties of any kind to you or any third party, whether arising from usage or custom or trade or by operation of law or otherwise, including but not limited to the following:  
+  a. any representations or warranties as to the accuracy, completeness, reliability, timeliness, currency, quality or fitness for any particular purpose of the Contents of this Website; and  
+  b. any representations or warranties that the Contents and functions available on this Website shall be error-free or shall be available without interruption or delay, or that any defects on this Website shall be rectified or corrected, or that this Website, the Contents and the hosting servers are and will be free of all viruses and other harmful elements.
 
-2. GovTech shall not be liable to you or any third party for any damage or loss whatsoever, including but not limited to direct, indirect, punitive, special or consequential damages, loss of income, revenue or profits, lost or damaged data, or damage to your computer, software, modem or other property, arising directly or indirectly from:
-   : a. your access to or use of this Website;
-   : b. any loss of access to or use of this Website, howsoever caused;
-   : c. any inaccuracy or incompleteness in, or errors or omissions in the transmission of, the Contents;
-   : d. any delay or interruption in the transmission of the Contents on this Website, whether caused by delay or interruption in transmission over the internet or otherwise; or
-   : e. any decision made or action taken by you or any third party in reliance upon the Contents,
-   regardless of whether GovTech has been advised of the possibility of such damage or loss.
+2. GovTech shall not be liable to you or any third party for any damage or loss whatsoever, including but not limited to direct, indirect, punitive, special or consequential damages, loss of income, revenue or profits, lost or damaged data, or damage to your computer, software, modem or other property, arising directly or indirectly from:  
+  a. your access to or use of this Website;  
+  b. any loss of access to or use of this Website, howsoever caused;  
+  c. any inaccuracy or incompleteness in, or errors or omissions in the transmission of, the Contents;  
+  d. any delay or interruption in the transmission of the Contents on this Website, whether caused by delay or interruption in transmission over the internet or otherwise; or  
+  e. any decision made or action taken by you or any third party in reliance upon the Contents, regardless of whether GovTech has been advised of the possibility of such damage or loss.  
 
 3. You shall not rely on any Contents of this Website to claim or assert any form of legitimate expectation against GovTech, whether procedural or substantive in nature, in respect of any action that GovTech may or may not take in the exercise of its discretion, or in connection with GovTech’s roles as a statutory agency.
 
 ### **Indemnity**
 
-1. You hereby agree to indemnify GovTech and hold GovTech harmless from and against any and all claims, losses, liabilities, costs and expenses (including but not limited to legal costs and expenses on a full indemnity basis) made against or suffered or incurred by GovTech arising directly or indirectly out of:
-   : a. your access to or use of this Website; or
-   : b. your breach of any of these Terms of Use.
+1. You hereby agree to indemnify GovTech and hold GovTech harmless from and against any and all claims, losses, liabilities, costs and expenses (including but not limited to legal costs and expenses on a full indemnity basis) made against or suffered or incurred by GovTech arising directly or indirectly out of:  
+  a. your access to or use of this Website; or  
+  b. your breach of any of these Terms of Use.  
 
 ### **Availability, Right of Access, Changes to Website and Contents**
 


### PR DESCRIPTION
This sub-list syntax (copied from govtech website terms of use):
   : a.
   : b.

is not supported in CommonMarkGhPages, which we are using instead of kramdown.